### PR TITLE
Add bundler tasks to Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,12 @@
 require 'rake/testtask'
+require 'bundler'
 
 Rake::TestTask.new do |t|
   t.libs << 'test'
   t.test_files = FileList['test/**/test_*.rb']
   t.verbose = true
 end
+
+Bundler::GemHelper.install_tasks
 
 task default: :test


### PR DESCRIPTION
This allows rake tasks for build install & release.

Thought this might be useful - since the README already mentioned builder, I figured it was okay to assume that it's required to use on the project.
